### PR TITLE
Move compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The simplest way to use SweetAlertDialog is to add the library as aar dependency
     }
 
     dependencies {
-        compile 'com.github.f0ris.sweetalert:library:1.5.6'
+        implementation 'com.github.f0ris.sweetalert:library:1.5.6'
     }
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,13 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 
@@ -17,5 +21,9 @@ allprojects {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 08 00:10:34 EEST 2017
+#Fri Oct 05 22:47:00 WIB 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,7 +18,7 @@ android {
 }
 
 dependencies {
-    compile 'com.pnikosis:materialish-progress:1.7'
+    implementation 'com.pnikosis:materialish-progress:1.7'
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,5 +28,5 @@ android {
 
 dependencies {
     //compile 'cn.pedant.sweetalert:library:1.3'
-    compile project(':library')
+    implementation project(':library')
 }


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
