### PR TITLE
Renamed custom attribute pivotX and pivotY attributes

### DIFF
--- a/library/src/main/java/cn/pedant/SweetAlert/Rotate3dAnimation.java
+++ b/library/src/main/java/cn/pedant/SweetAlert/Rotate3dAnimation.java
@@ -69,11 +69,11 @@ public class Rotate3dAnimation extends Animation {
         mFromDegrees = a.getFloat(R.styleable.Rotate3dAnimation_fromDeg, 0.0f);
         mToDegrees = a.getFloat(R.styleable.Rotate3dAnimation_toDeg, 0.0f);
         mRollType = a.getInt(R.styleable.Rotate3dAnimation_rollType, ROLL_BY_X);
-        Description d = parseValue(a.peekValue(R.styleable.Rotate3dAnimation_pivotX));
+        Description d = parseValue(a.peekValue(R.styleable.Rotate3dAnimation_customPivotX));
         mPivotXType = d.type;
         mPivotXValue = d.value;
 
-        d = parseValue(a.peekValue(R.styleable.Rotate3dAnimation_pivotY));
+        d = parseValue(a.peekValue(R.styleable.Rotate3dAnimation_customPivotY));
         mPivotYType = d.type;
         mPivotYValue = d.value;
 

--- a/library/src/main/res/anim/error_frame_in.xml
+++ b/library/src/main/res/anim/error_frame_in.xml
@@ -14,7 +14,7 @@
         sweet:rollType="x"
         sweet:fromDeg="100"
         sweet:toDeg="0"
-        sweet:pivotX="50%"
-        sweet:pivotY="50%"
+        sweet:customPivotX="50%"
+        sweet:customPivotY="50%"
         android:duration="400"/>
 </set>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,8 +8,8 @@
         </attr>
         <attr name="fromDeg" format="float" />
         <attr name="toDeg" format="float" />
-        <attr name="pivotX" format="fraction"/>
-        <attr name="pivotY" format="fraction" />
+        <attr name="customPivotX" format="fraction"/>
+        <attr name="customPivotY" format="fraction" />
     </declare-styleable>
 
     <attr name="sweet_alert_bg_drawable" format="reference" />


### PR DESCRIPTION
This PR changes the names of "pivotX" and "pivotY" attributes to "customPivotX" and "customPivotY" to avoid conflicts with the latest version of constraint layout that also has "pivotX" and "pivotY" as attributes.

I've changed the attributes and tested with the sample provided